### PR TITLE
Adds SWR calculation. Reports SWR to stderr, or 99.90:1 in case of error.

### DIFF
--- a/lib/HermesProxy.cc
+++ b/lib/HermesProxy.cc
@@ -370,13 +370,34 @@ void HermesProxy::ReceiveRxIQ(unsigned char * inbuf)	// called by metis Rx threa
 			  SlowCount++;
 			  if ((SlowCount & 0x1ff) == 0x1ff)
 			  {
-			    float FwdPwr = (float)AIN1 * (float)AIN1 / 145000.0;
-			    float RevPwr = (float)AIN2 * (float)AIN2 / 145000.0;
+				float FwdPwr = (float)AIN1 * (float)AIN1 / 145000.0;
+				float RevPwr = (float)AIN2 * (float)AIN2 / 145000.0;
 
-			    fprintf(stderr, "AlexFwdPwr = %4.0f  AlexRevPwr = %4.0f   ", FwdPwr, RevPwr);
-			    fprintf(stderr, "ADCOver: %u  HermesVersion: %d (dec)  %X (hex)\n", ADCoverload, HermesVersion, HermesVersion);
-			    //fprintf(stderr, "AIN1:%u  AIN2:%u  AIN3:%u  AIN4:%u  AIN5:%u  AIN6:%u\n", AIN1, AIN2, AIN3, AIN4, AIN5, AIN6);  
-			    } 
+				// calculate SWR
+				double SWR =  0.0;
+				try
+				{
+					SWR = (1+sqrt(RevPwr/FwdPwr))/(1-sqrt(RevPwr/FwdPwr));
+					if(false == std::isnormal(SWR))
+					{
+						throw;
+					}
+				}
+				catch(...)
+				{
+					// there was an anomaly in the SWR calculation, make it obvious ...
+					SWR =  99.9;
+				}
+
+				fprintf(stderr, "AlexFwdPwr = %4.0f  AlexRevPwr = %4.0f   ", FwdPwr, RevPwr);
+				// report SWR if forward power is non-zero
+				if(static_cast<int>(FwdPwr) != 0)
+				{
+					fprintf(stderr, "SWR = %.2f:1 ", SWR);
+				}
+				fprintf(stderr, "ADCOver: %u  HermesVersion: %d (dec)  %X (hex)\n", ADCoverload, HermesVersion, HermesVersion);
+				//fprintf(stderr, "AIN1:%u  AIN2:%u  AIN3:%u  AIN4:%u  AIN5:%u  AIN6:%u\n", AIN1, AIN2, AIN3, AIN4, AIN5, AIN6);  
+				}
 			}
 		} //endif sync is valid
 		

--- a/lib/HermesProxy.cc
+++ b/lib/HermesProxy.cc
@@ -380,10 +380,10 @@ void HermesProxy::ReceiveRxIQ(unsigned char * inbuf)	// called by metis Rx threa
 					SWR = (1+sqrt(RevPwr/FwdPwr))/(1-sqrt(RevPwr/FwdPwr));
 					if(false == std::isnormal(SWR))
 					{
-						throw;
+						throw 0;
 					}
 				}
-				catch(...)
+				catch(int& e)
 				{
 					// there was an anomaly in the SWR calculation, make it obvious ...
 					SWR =  99.9;


### PR DESCRIPTION
This patch adds SWR calculation. It reports SWR to stderr if forward power is non-zero. A reported value of 99.90:1 indicates that an anomaly occurred during calculation.

I am now wondering about a way to make the forward power and reverse power available in a flowgraph.
