### PR TITLE
GNURadio 3.8 category fix (and SIOCGIFHWADDR issue)

### DIFF
--- a/grc/hpsdr_hermesNB.block.yml
+++ b/grc/hpsdr_hermesNB.block.yml
@@ -2,7 +2,7 @@
 
 id: hpsdr_hermesNB
 label: hermesNB
-category: hpsdr
+category: '[HPSDR]'
 flags:
 - throttle
 

--- a/grc/hpsdr_hermesWB.block.yml
+++ b/grc/hpsdr_hermesWB.block.yml
@@ -2,7 +2,7 @@
 
 id: hpsdr_hermesWB
 label: hermesWB
-category: hpsdr
+category: '[HPSDR]'
 flags:
 - throttle
 


### PR DESCRIPTION
This fix the category on gnuradio 3.8.

You should also avoid `SIOCGIFHWADDR` at [metis.cc line 163](https://github.com/Tom-McDermott/gr-hpsdr/blob/master/lib/metis.cc#L163) since it doesn't work with macOS and other *BSDs (I would like to made available gr-hpsdr on [macports](https://www.macports.org)). Use `getifaddrs()`.