### PR TITLE
Add YAML manifest, install examples, add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# In GNU Radio 3.9+, pybind11 compares hash values of headers and source
+# files against knowns values.  Conversion of values to CRLF on checkout
+# break those checks so keep LF values when files are subject to said checks
+#
+*.h    text eol=lf
+*.c    text eol=lf
+*.cc   text eol=lf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,7 @@ add_custom_target(uninstall
 add_subdirectory(include/gnuradio/hpsdr)
 add_subdirectory(lib)
 add_subdirectory(apps)
+add_subdirectory(examples)
 add_subdirectory(docs)
 # NOTE: manually update below to use GRC to generate C++ flowgraphs w/o python
 if(ENABLE_PYTHON)
@@ -148,4 +149,8 @@ configure_package_config_file(
     ${CMAKE_CURRENT_BINARY_DIR}/cmake/Modules/${target}Config.cmake
     INSTALL_DESTINATION ${GR_CMAKE_DIR}
 )
+
+install(FILES MANIFEST.yml
+    RENAME MANIFEST-${VERSION_MAJOR}.${VERSION_API}.${VERSION_ABI}${VERSION_PATCH}.yml
+    DESTINATION share/gnuradio/manifests/hpsdr)
 

--- a/MANIFEST.yml
+++ b/MANIFEST.yml
@@ -1,0 +1,36 @@
+title: The HPSDR OOT Module
+version: 1.0
+brief: modules for OpenHPSDR Hermes / Metis and Red Pitaya
+tags: # Tags are arbitrary, but look at CGRAN what other authors are using
+  - Hermes
+  - Metis
+  - Red Pitaya
+  - OpenHpsdr
+author:
+  - Tom McDermott, N5EG
+copyright_owner:
+  - Tom McDermott, N5EG
+license: GPL-2.0-or-later
+gr_supported_version:
+  - 3.7
+  - 3.8
+  - 3.9
+  - 3.10
+repo: https://github.com/Tom-McDermott/gr-hpsdr
+website: https://github.com/Tom-McDermott/gr-hpsdr
+#icon: # Put a URL to a square image here that will be used as an icon
+description: |-
+  gnuradio modules for OpenHPSDR Hermes / Metis and Red Pitaya using the OpenHpsdr protocol. May 2021
+
+  hermesNB sources decimated downconverted 48K-to-384K receiver complex stream(s), and sinks one 48k sample rate transmit complex stream.
+
+  hermesWB sources raw ADC samples as a vector of floats, with vlen=16384. Each individual vector contains time contiguous samples. However there are large time gaps between between vectors. This is how HPSDR produces raw samples, it is due to Ethernet interface rate limitations between HPSDR and the host computer.
+
+  The modules are compatible with version 3.9.x of gnuradio and Hermes firmware version 1.8 through 3.2 (known as OpenHPSDR protocol 1). It is not compatible with the new OpenHPSDR protocol 2.
+
+  Updated to increase the maximum number of receivers to 7. Hermes only supports 4 receivers due to limited FPGA capacity. Red Pitaya with the OpenHPSDR protocol supports 6 receivers. Note that beyond 4 receivers and 384k sample rate exceeds 100 Mb/s Ethernet interface capacity.
+
+  If no Alex module is present (just Hermes/Metis) then the Alex control fields will have no effect, and the Verbose mode will produce nonsense for Fwd and Rev power measurements, but valid Hermes FPGA revision string.
+
+  It is sometimes necessary to delete all files inside the build subdirectory before re-running cmake.
+file_format: 1

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,1 @@
+install(FILES DESTINATION share/gnuradio/examples/hpsdr)


### PR DESCRIPTION
1. YAML manifest is installed and will be used by GRC-Qt for its OOT module browser
2. Install examples to directory that is discoverable by GRC-Qt example browser
3. Force checkouts on Windows to use Unix-style line endings so that the Python binding header hash check does not fail